### PR TITLE
Enable unit tests with ScalaTest

### DIFF
--- a/impro3-ss14-scala/pom.xml
+++ b/impro3-ss14-scala/pom.xml
@@ -28,6 +28,10 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest_2.11</artifactId>
+        </dependency>
 
         <!-- Arguments parsing -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,12 @@
                 <version>${junit.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.scalatest</groupId>
+                <artifactId>scalatest_2.11</artifactId>
+                <version>${scalatest.version}</version>
+                <scope>test</scope>
+            </dependency>
 
             <!-- Arguments parsing -->
             <dependency>
@@ -150,6 +156,24 @@
                         <include>**/*Specs.class</include>
                     </includes>
                 </configuration>
+            </plugin>
+            <plugin>
+              <groupId>org.scalatest</groupId>
+              <artifactId>scalatest-maven-plugin</artifactId>
+              <version>1.0-RC2</version>
+              <configuration>
+                <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+                <junitxml>.</junitxml>
+                <filereports>WDF TestSuite.txt</filereports>
+              </configuration>
+              <executions>
+                <execution>
+                  <id>test</id>
+                  <goals>
+                    <goal>test</goal>
+                  </goals>
+                </execution>
+              </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
This is the pull request to introduce ScalaTest framework to the common project repository
as suggested by @aalexandrov in https://github.com/TU-Berlin-DIMA/IMPRO-3.SS14/issues/1

A test spec to try this setup out could be:

```
package de.tu_berlin.impro3.scala.classification.randomforest

import org.scalatest._

class TreeSpec extends FlatSpec with Matchers {

  "A tree" should "always be happy!" in {
    true should be (true)
  }
}
```
